### PR TITLE
Make the HTTP response object available when throwing an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ There are some shortcut methods available on the Observable object that is retur
 
 ```js
 rxFetch('http://tangledfruit.com/mumble.txt').failOnHttpError()
-  // -> This Observable will yield an onError notification if the HTTP status
-  // code is >= 400.
+  // -> This Observable will yield an onError notification using the HttpError
+  // object described below if the HTTP status code is >= 400.
 ```
 
 ```js
 rxFetch('http://tangledfruit.com/mumble.txt').failIfStatusNotIn([200, 404])
-  // -> This Observable will yield an onError notification if the HTTP status
-  // code is anything other than 200 or 404.
+  // -> This Observable will yield an onError notification using the HttpError
+  // object described below if the HTTP status code is anything other than the
+  // codes listed (in this case, 200 and 404).
 ```
 
 ```js
@@ -83,6 +84,16 @@ rxFetch('http://tangledfruit.com/mumble.txt').json()
   // body of the HTTP response parsed as JSON. The HTTP headers and status are
   // discarded. This call implies .failOnHttpError().
 ```
+
+### HTTP Error object
+
+The `.failOnHttpError` and `.failIfStatusNotIn` methods will send an `onError`
+notification with an `HttpError` object. This is the standard `Error` Object,
+but it has an extra member `response` from which you can access other properties
+as described earlier.
+
+The message for the error will be "HTTP Error (status code): (server message)".
+For example, "HTTP Error 404: Not Found".
 
 
 ## License

--- a/lib/rx-fetch.js
+++ b/lib/rx-fetch.js
@@ -51,12 +51,16 @@ module.exports = function (url, options) {
   const result = Rx.Observable.fromPromise(fetch(url, options))
     .map((promiseResponse) => new rxResponse(promiseResponse));
 
+  const throwHttpError = function (response) {
+    var err = new Error("HTTP Error " + response.status + ": " + response.statusText);
+    err.response = response;
+    throw err;
+  };
+
   result.failOnHttpError = function () {
     return result.map((response) => {
-      if (!response.ok) {
-        throw new Error("Bad HTTP response");
-          // TBD: How to provide more info about failure?
-      }
+      if (!response.ok)
+        throwHttpError(response);
       return response;
     });
   };
@@ -67,10 +71,8 @@ module.exports = function (url, options) {
       throw new Error("acceptableStatusCodes must be an Array");
 
     return result.map((response) => {
-      if (acceptableStatusCodes.indexOf(response.status) === -1) {
-        throw new Error("Bad HTTP response");
-          // TBD: How to provide more info about failure?
-      }
+      if (acceptableStatusCodes.indexOf(response.status) === -1)
+        throwHttpError(response);
       return response;
     });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -217,8 +217,13 @@ describe('rx-fetch', function () {
 
       const fetchResult = rxFetch('http://tangledfruit.com/fail.txt').failOnHttpError();
 
-      expectOnlyError(fetchResult, done);
-        // TBD: How to provide access to the error information?
+      expectOnlyError(fetchResult, done,
+        function (error) {
+          expect(error).to.be.an.instanceof(Error);
+          expect(error.message).to.match(/^HTTP Error 404:/);
+          expect(error.response.status).to.equal(404);
+          expect(error.response.url).to.equal("http://tangledfruit.com/fail.txt");
+        });
 
     });
 
@@ -269,8 +274,13 @@ describe('rx-fetch', function () {
 
       const fetchResult = rxFetch('http://tangledfruit.com/fail.txt').failIfStatusNotIn([200, 400]);
 
-      expectOnlyError(fetchResult, done);
-        // TBD: How to provide access to the error information?
+      expectOnlyError(fetchResult, done,
+        function (error) {
+          expect(error).to.be.an.instanceof(Error);
+          expect(error.message).to.match(/^HTTP Error 404:/);
+          expect(error.response.status).to.equal(404);
+          expect(error.response.url).to.equal("http://tangledfruit.com/fail.txt");
+        });
 
     });
 
@@ -304,7 +314,14 @@ describe('rx-fetch', function () {
         .reply(404, bad);
 
       const fetchResult = rxFetch('http://tangledfruit.com/fail.txt').text();
-      expectOnlyError(fetchResult, done);
+
+      expectOnlyError(fetchResult, done,
+        function (error) {
+          expect(error).to.be.an.instanceof(Error);
+          expect(error.message).to.match(/^HTTP Error 404:/);
+          expect(error.response.status).to.equal(404);
+          expect(error.response.url).to.equal("http://tangledfruit.com/fail.txt");
+        });
 
     });
 
@@ -338,7 +355,14 @@ describe('rx-fetch', function () {
         .reply(404, bad);
 
       const fetchResult = rxFetch('http://tangledfruit.com/fail.txt').json();
-      expectOnlyError(fetchResult, done);
+
+      expectOnlyError(fetchResult, done,
+        function (error) {
+          expect(error).to.be.an.instanceof(Error);
+          expect(error.message).to.match(/^HTTP Error 404:/);
+          expect(error.response.status).to.equal(404);
+          expect(error.response.url).to.equal("http://tangledfruit.com/fail.txt");
+        });
 
     });
 


### PR DESCRIPTION
Fixes #6.
