### PR TITLE
If a predefined fetch function exists, don't replace it.

### DIFF
--- a/lib/rx-fetch.js
+++ b/lib/rx-fetch.js
@@ -1,8 +1,13 @@
 'use strict';
 
 const Rx = require('rx');
-require('isomorphic-fetch');
 
+// React Native predefines a suitable fetch function. If it's available,
+// use it; if not, let's find one.
+
+if (typeof(fetch) === 'undefined') {
+  require('isomorphic-fetch');
+}
 
 const rxResponse = function (promiseResponse) {
   this._promiseResponse = promiseResponse;


### PR DESCRIPTION
This happens in React Native.
